### PR TITLE
Delete N characters if numeric prefix argument.

### DIFF
--- a/smart-hungry-delete.el
+++ b/smart-hungry-delete.el
@@ -185,7 +185,8 @@ word--, else fall back to (delete-backward-char 1).
 With PREFIX just delete one char."
   (interactive "P")
   (if prefix
-      (if backwards (delete-char -1) (delete-char 1))
+      (let ((num (if (integerp prefix) prefix 1)))
+        (if backwards (delete-char (- num)) (delete-char num)))
   (let (check kill-end-match change-point fallback)
     (if backwards
         (setq check (lambda (regexp)


### PR DESCRIPTION
If the user provides a `C-u` prefix argument, delete one character as usual. If the user Provides a numeric prefix argument (such as `C-u 8` or `M-8`) delete that many (i.e. 8) characters.